### PR TITLE
feat: Implement initial database schema for sleep logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ target/ # if using Maven
 logs/
 *.log
 .DS_Store
+.vscode/
+bin/
+/db/

--- a/sleep/build.gradle
+++ b/sleep/build.gradle
@@ -5,6 +5,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'org.jetbrains.kotlin.jvm' version '1.6.21'
 	id 'org.jetbrains.kotlin.plugin.spring' version '1.6.21'
+	id 'jacoco'
 }
 
 group = 'com.noom.interview.fullstack'
@@ -21,11 +22,16 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
+	testImplementation 'org.mockito:mockito-core'
+	testImplementation 'org.mockito:mockito-junit-jupiter'
 }
 
 tasks.withType(KotlinCompile) {
@@ -41,4 +47,19 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+test {
+    finalizedBy jacocoTestReport
 }

--- a/sleep/src/main/resources/application-unittest.properties
+++ b/sleep/src/main/resources/application-unittest.properties
@@ -1,1 +1,13 @@
+# Disable Flyway for unit tests if you don't want it to run migrations against H2
 spring.flyway.enabled=false
+
+# H2 Database Configuration for tests
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+
+# JPA Configuration
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=true

--- a/sleep/src/main/resources/db/migration/V1.1__create_sleep_logs_table.sql
+++ b/sleep/src/main/resources/db/migration/V1.1__create_sleep_logs_table.sql
@@ -1,0 +1,32 @@
+-- Create users table.
+CREATE TABLE IF NOT EXISTS users (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create sleep_logs table.
+CREATE TABLE IF NOT EXISTS sleep_logs (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL, 
+    sleep_date DATE NOT NULL,
+    time_in_bed_start TIMESTAMP WITH TIME ZONE NOT NULL,
+    time_in_bed_end TIMESTAMP WITH TIME ZONE NOT NULL,
+    total_time_in_bed_minutes INTEGER NOT NULL,
+    morning_feeling TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_morning_feeling CHECK (morning_feeling IN ('BAD', 'OK', 'GOOD')),
+
+    CONSTRAINT fk_user
+        FOREIGN KEY(user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT chk_time_order CHECK (time_in_bed_end > time_in_bed_start),
+
+    CONSTRAINT uq_user_sleep_date UNIQUE (user_id, sleep_date)
+);
+
+-- Create index for user_id and sleep_date.
+CREATE INDEX IF NOT EXISTS idx_sleep_logs_user_id_sleep_date ON sleep_logs (user_id, sleep_date DESC);


### PR DESCRIPTION
This PR introduces the foundational database schema required for the sleep logging application.

Key changes:
- Defines the `users` table.
- Defines the `sleep_logs` table with columns for sleep date, start/end times, duration, and morning feeling.
- Establishes a foreign key relationship between `sleep_logs` and `users`.
- Adds necessary constraints (PK, FK, NOT NULL, UNIQUE for user/sleep_date, CHECK for time order).
- Sets up indexes for efficient querying on `user_id` and `sleep_date`.
- Implemented as a Flyway migration script (`V1.1__create_sleep_logs_table.sql`).